### PR TITLE
Detect ATRAC3 renamed for custom music in GTA LCS/VCS for PSP

### DIFF
--- a/source/audio/at3.c
+++ b/source/audio/at3.c
@@ -352,7 +352,7 @@ int AT3_Init(const char *path) {
 	char* ext = sceClibStrrchr(path, '.');
 	if (!sceClibStrncasecmp(ext, ".oma", 4) || !sceClibStrncasecmp(ext, ".aa3", 4))
 		return AT3_Init_OMA(path);
-	else if (!sceClibStrncasecmp(ext, ".at3", 4))
+	else if (!sceClibStrncasecmp(ext, ".at3", 4) || !sceClibStrncasecmp(ext, ".gta", 4))
 		return AT3_Init_RIFF(path);
 	else
 		return -1;

--- a/source/audio/audio.c
+++ b/source/audio/audio.c
@@ -86,7 +86,7 @@ int Audio_Init(const char *path) {
 		file_type = FILE_TYPE_ATRAC9;
 	else if ((!sceClibStrncasecmp(FS_GetFileExt(path), "m4a", 3)) || (!sceClibStrncasecmp(FS_GetFileExt(path), "aac", 3)))
 		file_type = FILE_TYPE_AAC;
-	else if ((!sceClibStrncasecmp(FS_GetFileExt(path), "oma", 3)) || (!sceClibStrncasecmp(FS_GetFileExt(path), "aa3", 3)) || (!sceClibStrncasecmp(FS_GetFileExt(path), "at3", 3)))
+	else if ((!sceClibStrncasecmp(FS_GetFileExt(path), "oma", 3)) || (!sceClibStrncasecmp(FS_GetFileExt(path), "aa3", 3)) || (!sceClibStrncasecmp(FS_GetFileExt(path), "at3", 3)) || (!sceClibStrncasecmp(FS_GetFileExt(path), "gta", 3)))
 		file_type = FILE_TYPE_AT3;
 
 	switch(file_type) {

--- a/source/dirbrowse.c
+++ b/source/dirbrowse.c
@@ -190,7 +190,7 @@ void Dirbrowse_DisplayFiles(void) {
 				|| (!sceClibStrncasecmp(file->ext, "s3m", 4)) || (!sceClibStrncasecmp(file->ext, "wav", 4)) || (!sceClibStrncasecmp(file->ext, "xm", 4))
 				|| (!sceClibStrncasecmp(file->ext, "at9", 4)) || (!sceClibStrncasecmp(file->ext, "m4a", 4)) || (!sceClibStrncasecmp(file->ext, "aac", 4))
 				|| (!sceClibStrncasecmp(file->ext, "oma", 4)) || (!sceClibStrncasecmp(file->ext, "aa3", 4)) || (!sceClibStrncasecmp(file->ext, "at3", 4))
-                || (!sceClibStrncasecmp(file->ext, "gta", 4)))
+				|| (!sceClibStrncasecmp(file->ext, "gta", 4)))
 				vita2d_draw_texture(icon_audio, 15, 117 + (72 * printed));
 			else
 				vita2d_draw_texture(icon_file, 15, 117 + (72 * printed));

--- a/source/dirbrowse.c
+++ b/source/dirbrowse.c
@@ -187,9 +187,10 @@ void Dirbrowse_DisplayFiles(void) {
 				vita2d_draw_texture(icon_dir, 15, 117 + (72 * printed));
 			else if ((!sceClibStrncasecmp(file->ext, "flac", 4)) || (!sceClibStrncasecmp(file->ext, "it", 4)) || (!sceClibStrncasecmp(file->ext, "mod", 4))
 				|| (!sceClibStrncasecmp(file->ext, "mp3", 4)) || (!sceClibStrncasecmp(file->ext, "ogg", 4)) || (!sceClibStrncasecmp(file->ext, "opus", 4))
-				|| (!sceClibStrncasecmp(file->ext, "s3m", 4))|| (!sceClibStrncasecmp(file->ext, "wav", 4)) || (!sceClibStrncasecmp(file->ext, "xm", 4))
+				|| (!sceClibStrncasecmp(file->ext, "s3m", 4)) || (!sceClibStrncasecmp(file->ext, "wav", 4)) || (!sceClibStrncasecmp(file->ext, "xm", 4))
 				|| (!sceClibStrncasecmp(file->ext, "at9", 4)) || (!sceClibStrncasecmp(file->ext, "m4a", 4)) || (!sceClibStrncasecmp(file->ext, "aac", 4))
-				|| (!sceClibStrncasecmp(file->ext, "oma", 4)) || (!sceClibStrncasecmp(file->ext, "aa3", 4)) || (!sceClibStrncasecmp(file->ext, "at3", 4)))
+				|| (!sceClibStrncasecmp(file->ext, "oma", 4)) || (!sceClibStrncasecmp(file->ext, "aa3", 4)) || (!sceClibStrncasecmp(file->ext, "at3", 4))
+                || (!sceClibStrncasecmp(file->ext, "gta", 4)))
 				vita2d_draw_texture(icon_audio, 15, 117 + (72 * printed));
 			else
 				vita2d_draw_texture(icon_file, 15, 117 + (72 * printed));

--- a/source/menus/menu_audioplayer.c
+++ b/source/menus/menu_audioplayer.c
@@ -84,7 +84,7 @@ static int Menu_GetMusicList(void) {
 				(!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "xm", 4)) || (!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "at9", 4)) ||
 				(!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "m4a", 4)) || (!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "aac", 4)) ||
 				(!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "oma", 4)) || (!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "aa3", 4)) ||
-				(!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "at3", 4))) {
+				(!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "at3", 4)) || (!sceClibStrncasecmp(FS_GetFileExt(entries[i].d_name), "gta", 4))) {
 				strcpy(playlist[count], cwd);
 				strcpy(playlist[count] + strlen(playlist[count]), entries[i].d_name);
 				count++;


### PR DESCRIPTION
Custom music radio in Grand Theft Auto: Liberty City Stories and Vice City Stories for PSP (and, automatically, for Vita) are required to be (officially) made by some Windows tool made by Rockstar that creates files with `.gta` extension. These are in fact ATRAC3 files with `file` of `RIFF (little-endian) data, WAVE audio, stereo 44100 Hz`.
Currently, playing them in ElevenMPV requires listener to rename all the files to `.at3` extension in order to play them. I don't think it's possible to get any other files with this extension in normal Vita usage.